### PR TITLE
Default root to OS tmp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var tmp = require('tmp-sync');
 
 ### tmp.in(root)
 
-- root `path` the root path for the temp directory
+- root `path` the root path for the temp directory (default to OS tmp directory)
 
 Makes a temp dir inside `root` and returns `path` the newly created dir.
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ tmp._dir = function (dir) {
 
 // genarate an random name inside a directory
 tmp.in = function (root) {
+    root = root || require('osenv').tmpdir();
     // Everytime it returns a different directory
     var dir = node_path.join(
         root,

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "keywords": [
     "tmp-sync",
-    "temporary", 
-    "tmp", 
-    "temp", 
-    "tempdir", 
-    "tempfile", 
-    "tmpdir", 
+    "temporary",
+    "tmp",
+    "temp",
+    "tempdir",
+    "tempfile",
+    "tmpdir",
     "tmpfile"
   ],
   "engines": {
@@ -33,6 +33,7 @@
     "chai": "~1.8.0"
   },
   "dependencies": {
-    "fs-sync": "^0.2.4"
+    "fs-sync": "^0.2.4",
+    "osenv": "^0.1.0"
   }
 }


### PR DESCRIPTION
If the root is not set, this just default to the base OS tmp directory.
