### PR TITLE
upgrade fs-sync, fix typos

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var tmp         = exports;
 var node_path   = require('path');
-var fs          = require('fs-sync'); 
+var fs          = require('fs-sync');
 
 
 // by name
@@ -19,13 +19,13 @@ tmp._dir = function (dir) {
 };
 
 
-// genarate an random name inside a directory
+// generate a random name inside a directory
 tmp.in = function (root) {
     root = root || require('osenv').tmpdir();
     // Everytime it returns a different directory
     var dir = node_path.join(
         root,
-        'tmp-' 
+        'tmp-'
             + process.pid + '-'
             + Number( '' + Date.now() + Math.random() * 0x1000000000 ).toString(36)
     );

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "url": "https://github.com/kaelzhang/node-tmp-sync/issues"
   },
   "devDependencies": {
-    "mocha": "~1.13.0",
-    "chai": "~1.8.0"
+    "chai": "~1.8.0",
+    "mocha": "~1.13.0"
   },
   "dependencies": {
-    "fs-sync": "^0.2.4",
+    "fs-sync": "^1.0.4",
     "osenv": "^0.1.0"
   }
 }


### PR DESCRIPTION
Found a few typos, and the older version of `fs-sync` depends on a much older version of lodash which gets included in a lot of transitive dependencies. 